### PR TITLE
Ajax status code strings should not be internationalized

### DIFF
--- a/proctoru/proctoru.py
+++ b/proctoru/proctoru.py
@@ -153,7 +153,7 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
 
     def _is_studio(self):
         """
-        This Function checks if call is from CMS or LMS and returns boolean 
+        This Function checks if call is from CMS or LMS and returns boolean
         True if call is from studio.
         """
         studio = False
@@ -165,14 +165,14 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
 
     def _user_is_staff(self):
         """
-        This Function checks if user is staff and returns boolean 
+        This Function checks if user is staff and returns boolean
         True if user is staff.
         """
         return getattr(self.runtime, 'user_is_staff', False)
 
     def _allowed_verified(self):
         """
-        This Function checks if user is staff and returns boolean 
+        This Function checks if user is staff and returns boolean
         True if user is staff.
         """
         course_enrollment = CourseEnrollment.objects.get(
@@ -740,7 +740,7 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
         """
         self.exam_date = data.get('date')
         return {
-            'status': _('success')
+            'status': 'success'
         }
 
     @XBlock.json_handler
@@ -751,7 +751,7 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
         self.student_old_time_zone = self.student_time_zone
         self.is_rescheduled = True
         return {
-            'status': _('success')
+            'status': 'success'
         }
 
     @XBlock.json_handler
@@ -793,12 +793,12 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
                 exam_data.save()
             self.is_exam_start_clicked = True
             return {
-                'status': _('success'),
+                'status': 'success',
                 'reservation_data': reservation_data.get('data')
             }
         else:
             return {
-                'status': _('error')
+                'status': 'error'
             }
 
     @XBlock.json_handler
@@ -836,16 +836,16 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
                 User.objects.get(pk=self.runtime.user_id), self.get_block_id())
             if exam_status:
                 return {
-                    'status': _('success')
+                    'status': 'success'
                 }
             else:
                 return {
-                    'status': _('error'),
+                    'status': 'error',
                     'msg': _('Database error'),
                 }
         else:
             return {
-                'status': _('error'),
+                'status': 'error',
                 'msg': _("invalid password")
             }
 
@@ -861,11 +861,11 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
             User.objects.get(pk=self.runtime.user_id), self.get_block_id())
         if exam_status:
             return {
-                'status': _('success')
+                'status': 'success'
             }
         else:
             return {
-                'status': _('error'),
+                'status': 'error',
                 'msg': _('Database error'),
             }
 
@@ -948,16 +948,16 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
             api_obj.set_exam_schedule_arrived(exam_data)
 
             return {
-                'status': _('success')
+                'status': 'success'
             }
         elif json_response.get('response_code') == 2:
             return {
-                'status': _('error'),
+                'status': 'error',
                 'msg': _('exam already scheduled')
             }
         else:
             return {
-                'status': _('error'),
+                'status': 'error',
                 'msg': _('Please contact administrator')
             }
 
@@ -967,7 +967,7 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
         Cancel Rescheduling.
         """
         self.is_rescheduled = False
-        return {"message": _('success')}
+        return {"message": 'success'}
 
     @XBlock.json_handler
     def edit_proctoru_account(self, data=None, suffix=""):

--- a/proctoru/proctoru.py
+++ b/proctoru/proctoru.py
@@ -21,6 +21,7 @@ from xblockutils2.studio_editable import StudioContainerXBlockMixin
 
 from .api import ProctoruAPI
 from .models import ProctoruUser
+from .settings import PROCTORU_EXAM_AWAY_TIMEOUT
 
 from .timezonemap import win_tz
 
@@ -427,7 +428,7 @@ class ProctorUXBlock(StudioContainerXBlockMixin, XBlock):
                             remaining_time = (
                                 diff.days * 24 * 60) + (diff.seconds/60)
 
-                            if remaining_time <= -15:
+                            if remaining_time <= PROCTORU_EXAM_AWAY_TIMEOUT:
                                 # if examtime pass away
                                 self.exam_time = ""
                                 self.is_exam_scheduled = False

--- a/proctoru/settings.py
+++ b/proctoru/settings.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+
+PROCTORU_EXAM_AWAY_TIMEOUT = getattr(settings, 'PROCTORU_EXAM_AWAY_TIMEOUT', -59)


### PR DESCRIPTION
As JS expects english status code response (https://github.com/perpetualny/proctoru-xblock/blob/master/proctoru/static/js/src/proctoru.js#L54) , those status are not recognized when user is not english.
Also, generaly speaking,  this kind of strings should not be internationalized

Note that the issue also exists on master branch
